### PR TITLE
Frontend toast notifications

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -161,7 +161,7 @@ class AttackGroup(SQLModel, table=True):
     created_by:     Client | None               = Relationship(back_populates="created_groups")
     exploit_id:     ExploitID                   = Field(foreign_key="exploits.id", ondelete="CASCADE")
     exploit:        Exploit                     = Relationship(back_populates="groups")
-    commit_id:     ExploitSourceID | None      = Field(foreign_key="exploit_sources.id", ondelete="SET NULL")
+    commit_id:      ExploitSourceID | None      = Field(foreign_key="exploit_sources.id", ondelete="SET NULL")
     commit:         ExploitSource | None        = Relationship(back_populates="executed_by_group")
     
     executions:     List["AttackExecution"]     = Relationship(back_populates="executed_by_group")
@@ -173,7 +173,7 @@ class AttackExecution(SQLModel, table=True):
     start_time:             DateTime | None            = Field(sa_column=datetime_now_sql(now=False))
     end_time:               DateTime | None            = Field(sa_column=datetime_now_sql(now=False))
     status:                 AttackExecutionStatus      = Field(index=True)
-    output:                  bytes | None
+    output:                 bytes | None
     received_at:            DateTime                   = Field(sa_column=datetime_now_sql(index=True))
     target_id:              TeamID | None              = Field(foreign_key="teams.id", ondelete="SET NULL")
     target:                 Team | None                = Relationship(back_populates="attacks_executions")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,16 +10,15 @@ import { LoadingOverlay, MantineProvider, Title } from '@mantine/core';
 import { LoginProvider } from '@/components/LoginProvider';
 import { Routes, Route, BrowserRouter } from "react-router";
 import { useGlobalStore, useTokenStore } from './utils/stores';
-import { statusQuery } from './utils/queries';
 import { HomePage } from './components/screens/HomePage';
 import { MainLayout } from './components/MainLayout';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { DEBOUNCED_SOCKET_IO_CHANNELS, socket_io, SOCKET_IO_CHANNELS, sockIoChannelToQueryKeys } from './utils/net';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDebouncedCallback } from '@mantine/hooks'
 import { CodeHighlightAdapterProvider, stripShikiCodeBlocks } from '@mantine/code-highlight';
 import { CodeHighlightAdapter } from 'node_modules/@mantine/code-highlight/lib/CodeHighlightProvider/CodeHighlightProvider';
-
+import { exploitsQuery, statsQuery, statusQuery } from './utils/queries';
 
 // Shiki requires async code to load the highlighter
 async function loadShiki() {
@@ -62,6 +61,14 @@ export default function App() {
     const queryClient = useQueryClient()
     const { setErrorMessage, loading:loadingStatus } = useGlobalStore()
     const { loginToken } = useTokenStore()
+    const stats = statsQuery()
+    const status = statusQuery()
+    const exploits = exploitsQuery()
+
+    // Debug notification
+    const lastDebugTickNotified = useRef<number | null>(null)
+    const lastWarningTickNotified = useRef<Record<string, number>>({})
+    const lastErrorTickNotified = useRef<Record<string, number>>({})
 
     const debouncedCalls = DEBOUNCED_SOCKET_IO_CHANNELS.map((channel) => (
         useDebouncedCallback(() => {
@@ -70,7 +77,108 @@ export default function App() {
             )
         }, 3000)
     ))
-    
+
+    useEffect(() => {
+        if (!stats.data || !exploits.data || !status.data?.services) return
+        if (stats.data.ticks.length == 0) return
+
+        const latestTick = stats.data.ticks[stats.data.ticks.length - 1]
+        if (!latestTick) return
+
+        const calcServicesStats = (tick: typeof latestTick) => {
+            const serviceStats : Record<string, {name : string, ok : number , total : number }> = {}
+            status.data?.services?.forEach((service) => {
+                serviceStats[service.id] = {
+                    name: service.name,
+                    ok: 0,
+                    total: 0,
+                }
+            })
+
+            Object.entries(tick.exploits).forEach(([exploitId, exploitStats]) => {
+                const exploit = exploits.data.find((item) => item.id === exploitId)
+                if (!exploit || !exploit.service || !exploitStats) return
+
+                const service = serviceStats[exploit.service]
+                if (!service) return
+
+                service.ok += exploitStats.flags.ok
+                service.total += exploitStats.flags.tot
+            })
+
+            return serviceStats
+        }
+
+        // Debug notification every 2 ticks
+        if(latestTick.tick % 2 == 0 && lastDebugTickNotified.current !== latestTick.tick) {
+            const serviceStats = calcServicesStats(latestTick)
+
+            const message = Object.values(serviceStats)
+                .map((service) => `${service.name}: ${service.ok}/${service.total} ok flags`)
+                .join("\n")
+
+            notifications.show({
+                title: `Debug stats - tick ${latestTick.tick}`,
+                message: <span style={{ whiteSpace: "pre-line" }}>{message}</span>,
+                color: "blue",
+                autoClose: 8000,
+            })
+
+            lastDebugTickNotified.current = latestTick.tick
+        }
+
+        // Warning if a service is stealing less flags than the previous 5 ticks average
+        if (stats.data.ticks.length >= 6) {
+            const previousTicks = stats.data.ticks.slice(-6, -1)
+            const currentServiceStats = calcServicesStats(latestTick)
+            const previousServicesStats = previousTicks.map((tick) => calcServicesStats(tick))
+
+            Object.entries(currentServiceStats).forEach(([serviceId, service]) => {
+                const previousTotal = previousServicesStats.reduce((tot, tickStats) => {
+                    return tot + (tickStats[serviceId]?.ok ?? 0)
+                }, 0)
+                const previousAvg = previousTotal / previousTicks.length
+
+                if (previousAvg <= 0) return
+                if (service.ok >= previousAvg) return
+                if (lastWarningTickNotified.current[serviceId] === latestTick.tick) return
+
+                notifications.show({
+                    title: `Low flags for ${service.name}`,
+                    message: `Tick ${latestTick.tick}: ${service.ok} ok flags, previous 5 ticks average: ${previousAvg.toFixed(1)}`,
+                    color: "yellow",
+                    autoClose: 10000,
+                })
+
+                lastWarningTickNotified.current[serviceId] = latestTick.tick
+            })
+        }
+
+        // Error if an exploit executes for 3 ticks and returns 0 ok flags
+        if (stats.data.ticks.length >= 3) {
+            const last3Ticks = stats.data.ticks.slice(-3)
+
+            exploits.data.forEach((exploit) => {
+                const failedFor3Ticks = last3Ticks.every((tick) => {
+                    const exploitStats = tick.exploits[exploit.id]
+                    return (exploitStats?.attacks.tot ?? 0) > 0 && (exploitStats?.flags.ok ?? 0) == 0
+                })
+
+                if (!failedFor3Ticks) return
+                if (lastErrorTickNotified.current[exploit.id] === latestTick.tick) return
+
+                notifications.show({
+                    title: `Exploit ${exploit.name} returned 0 flags`,
+                    message: `The exploit returned 0 ok flags for 3 ticks in a row.(SYS ADMIN FIX IT PLS PLS PLS !!!)`,
+                    color: "red",
+                    autoClose: false,
+                })
+
+                lastErrorTickNotified.current[exploit.id] = latestTick.tick
+            })
+        }
+    }, [stats.data, exploits.data, status.data?.services])
+
     useEffect(() => {
         SOCKET_IO_CHANNELS.forEach((channel) => {
             socket_io.on(channel, (_data) => {
@@ -122,8 +230,6 @@ export default function App() {
         socket_io.disconnect()
         socket_io.connect()
     }, [loginToken])
-
-    const status = statusQuery()
 
     return (
         <MantineProvider defaultColorScheme='dark'>


### PR DESCRIPTION
It's an introduction of toast notifications, for the frontend.
We added 3 notification 
1. A debug notification every 2, that report the status of the varius service so that the sysadmin can keep an AI on it 
2. A notification that if flags stolen are less then the previus 5 ticks, we sent a warring, to prevent the fact that maybe some exploits are not working anymore, or the farm isn't working properly
3. The last is that if an exploits for 3 ticks isn't returin any flags it got notificated (IN VERY BIG RED).

this is in draft because it's not fully tested.